### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ jobs:
   coverage:
     name: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/defi-sdk/security/code-scanning/8](https://github.com/Dargon789/defi-sdk/security/code-scanning/8)

In general, the fix is to explicitly declare a `permissions:` block in the workflow, either at the root (applying to all jobs) or within the specific job. This should grant only the minimal required scopes, typically `contents: read` for a basic CI job that only needs to read the repository contents.

For this workflow, the simplest, non-functional change is to add a job-level `permissions:` block under `coverage:` (or, alternatively, a root-level block under `name:`). Since the steps only check out code, set up Node, start an SSH agent, and run `npm ci`, they only need read access to repository contents. Therefore, adding:

```yaml
permissions:
  contents: read
```

is sufficient. Concretely, in `.github/workflows/test.yml`, edit the `coverage` job definition so that between `runs-on: ubuntu-latest` (line 7) and `steps:` (line 8) you insert the `permissions` block. No additional imports or methods are needed, as this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Build:
- Restrict the coverage job in the test workflow to read-only repository contents via an explicit permissions block.